### PR TITLE
CTR-only mode still needs functions to update counter (iv)

### DIFF
--- a/aes.c
+++ b/aes.c
@@ -226,7 +226,7 @@ void AES_init_ctx(struct AES_ctx* ctx, const uint8_t* key)
 {
   KeyExpansion(ctx->RoundKey, key);
 }
-#if defined(CBC) && (CBC == 1)
+#if (defined(CBC) && (CBC == 1)) || (defined(CTR) && (CTR == 1))
 void AES_init_ctx_iv(struct AES_ctx* ctx, const uint8_t* key, const uint8_t* iv)
 {
   KeyExpansion(ctx->RoundKey, key);

--- a/aes.h
+++ b/aes.h
@@ -49,7 +49,7 @@ struct AES_ctx
 };
 
 void AES_init_ctx(struct AES_ctx* ctx, const uint8_t* key);
-#if defined(CBC) && (CBC == 1)
+#if (defined(CBC) && (CBC == 1)) || (defined(CTR) && (CTR == 1))
 void AES_init_ctx_iv(struct AES_ctx* ctx, const uint8_t* key, const uint8_t* iv);
 void AES_ctx_set_iv(struct AES_ctx* ctx, const uint8_t* iv);
 #endif


### PR DESCRIPTION
When defining CTR-only mode, the `AES_init_ctx_iv` and `AES_ctx_set_iv` functions disappear, but this leaves no public API for updating the counter (iv).