### PR TITLE
Use `uint32_t` instead of `uintptr_t` for index.

### DIFF
--- a/aes.c
+++ b/aes.c
@@ -499,7 +499,7 @@ static void XorWithIv(uint8_t* buf, const uint8_t* Iv)
 
 void AES_CBC_encrypt_buffer(struct AES_ctx *ctx, uint8_t* buf, uint32_t length)
 {
-  uintptr_t i;
+  uint32_t i;
   uint8_t *Iv = ctx->Iv;
   for (i = 0; i < length; i += AES_BLOCKLEN)
   {
@@ -515,7 +515,7 @@ void AES_CBC_encrypt_buffer(struct AES_ctx *ctx, uint8_t* buf, uint32_t length)
 
 void AES_CBC_decrypt_buffer(struct AES_ctx* ctx, uint8_t* buf,  uint32_t length)
 {
-  uintptr_t i;
+  uint32_t i;
   uint8_t storeNextIv[AES_BLOCKLEN];
   for (i = 0; i < length; i += AES_BLOCKLEN)
   {


### PR DESCRIPTION
Thanks first of all for your nice library! As I'm using it on a 16-bit platform the pointer size would differ from `uint32_t`.