### PR TITLE
Add metadata for Arduino Library Manager

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,11 @@
+name=tiny-AES-c
+version=1.0.0
+author=kokke
+maintainer=kokke
+sentence=A small and portable implementation of the AES ECB, CTR and CBC encryption algorithms written in C.
+paragraph=You can override the default key-size of 128 bit with 192 or 256 bit by defining the symbols AES192 or AES256 in aes.h. The API is very simple. No padding is provided so for CBC and ECB all buffers should be multiples of 16 bytes.
+category=Data Processing
+url=https://github.com/kokke/tiny-AES-c
+repository=https://github.com/kokke/tiny-AES-c.git
+architectures=*
+includes=aes.h


### PR DESCRIPTION
Adding a library.properties file will allow the project to be indexed by the Arduino Library Manager.

https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ