### PR TITLE
Move includes to header

### DIFF
--- a/aes.c
+++ b/aes.c
@@ -35,8 +35,6 @@ NOTE:   String length must be evenly divisible by 16byte (str_len % 16 == 0)
 /*****************************************************************************/
 /* Includes:                                                                 */
 /*****************************************************************************/
-#include <stdint.h>
-#include <string.h> // CBC mode, for memset
 #include "aes.h"
 
 /*****************************************************************************/
@@ -569,4 +567,3 @@ void AES_CTR_xcrypt_buffer(struct AES_ctx* ctx, uint8_t* buf, uint32_t length)
 }
 
 #endif // #if defined(CTR) && (CTR == 1)
-

--- a/aes.h
+++ b/aes.h
@@ -2,6 +2,7 @@
 #define _AES_H_
 
 #include <stdint.h>
+#include <string.h> // CBC mode, for memset
 
 // #define the macros below to 1/0 to enable/disable the mode of operation.
 //


### PR DESCRIPTION
Move the includes from `aes.c` into `aes.h`

Is there a reason to have them in `aes.c` and have `#include <stdint.h>` in both files?