### PR TITLE
README: Add link to tinyaes Python wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,7 @@ A heartfelt thank-you to all the nice people out there who have contributed to t
 
 
 All material in this repository is in the public domain.
+
+## Wrappers
+
+- [`tinyaes-py`](https://github.com/naufraghi/tinyaes-py) is a minimal Cython wrapper, compatible with Python 3 but also Python 2 (fully thanks to Cython code generation)


### PR DESCRIPTION
Beside the shameless plug of my little wrapper, I've seen that in Python is quite easy to add some property-based test coverage to the library.

If you wish to suggest some more sensible test, I'll be glad to add them to the [wrapper tests](https://github.com/naufraghi/tinyaes-py/blob/master/tests/test_tinyaes.py#L48).