### PR TITLE
update cmakelists.txt to be able to use it in add_subdirectory()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,17 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.12)
 
-project(tinyaes C ASM)
+project(tiny-aes C)
 
-add_library(tiny-aes
-        aes.c
-        )
+add_library(${PROJECT_NAME} "")
+target_sources(${PROJECT_NAME}
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/aes.c
+    INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/aes.h
+        ${CMAKE_CURRENT_LIST_DIR}/aes.hpp
+)
 
-target_include_directories(tiny-aes PRIVATE tiny-AES-c/)
+target_include_directories(${PROJECT_NAME}
+    INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}
+)


### PR DESCRIPTION
- Remove reference to ASM language
- advance minimum version of the cmake required as far version 2 is VERY outdated. 
- remove hardcoded folder name of "tiny-AES-c as target_include_directory which by some reason is PRIVATE and could not be used as add_subdirectory() in main project.