### PR TITLE
Exclude tests from build in library.json for PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,13 +1,19 @@
 {
-  "name": "tiny-AES-c",
-  "keywords": "cryptography, aes",
-  "description": "Small portable AES128/192/256 in C",
-  "repository":
-  {
-    "type": "git",
-    "url": "https://github.com/kokke/tiny-AES-c.git"
-  },
-  "frameworks": "*",
-  "platforms": "*",
-  "examples": "test.c"
+    "version": "1.0.0",
+    "name": "tiny-AES-c",
+    "keywords": "cryptography, aes",
+    "description": "Small portable AES128/192/256 in C",
+    "repository":
+    {
+        "type": "git",
+        "branch": "master",
+        "url": "https://github.com/kokke/tiny-AES-c.git"
+    },
+    "frameworks": "*",
+    "platforms": "*",
+    "examples": "test.c",
+    "build":
+	{
+		"srcFilter": "+<*> -<.git/> -<test.c> -<test.cpp> -<test_package/>"
+	}
 }


### PR DESCRIPTION
Hi, thank you for the great library.

This PR fixes the build when using the PaltformIO system, where this library is listed as well (https://platformio.org/lib/show/5421/tiny-AES-c)
I added a `srcFilter` directive to the `build` section in the `library.json` file, to exclude the test programs when the project is compiled into a library. Without this change, the library clashes with the main user code:
```
Compiling .pio/build/uno/lib2ed/tiny-AES-c/aes.c.o
Compiling .pio/build/uno/lib2ed/tiny-AES-c/test.c.o
Compiling .pio/build/uno/lib2ed/tiny-AES-c/test.cpp.o
Archiving .pio/build/uno/lib2ed/libtiny-AES-c.a
Indexing .pio/build/uno/lib2ed/libtiny-AES-c.a
```

In addition, I added the most recent version number (1.0.0) to the library manifest file. This version bump should automatically update the version hosted on PlatformIO.