### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,15 @@ A heartfelt thank-you to [all the nice people](https://github.com/kokke/tiny-AES
 
 
 All material in this repository is in the public domain.
+
+### Installing from vcpkg
+
+You can download and install `tiny-aes-c` using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+```sh
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh #.\bootstrap-vcpkg.bat(for windows)
+./vcpkg integrate install
+./vcpkg install tiny-aes-c
+```
+The `tiny-aes-c` port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
`tiny-aes-c` available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `tiny-aes-c` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `tiny-aes-c`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/tiny-aes-c/portfile.cmake). We try to keep the library maintained as close as possible to the original library.