### PR TITLE
Remove cmake depreciation warning on newer versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /*.o
 /test.elf
 /test.map
-test_package/build
+**/build

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /*.o
 /test.elf
 /test.map
-**/build
+test_package/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12..3.29)
 
 project(tiny-aes C)
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.12..3.29)
 project(TinyAesPackageTest C CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
This PR aims to remove CMake depreciation message when building with recent CMake releases:
```cmake
[cmake] CMake Deprecation Warning at <snip!>/tiny-aes-src/CMakeLists.txt:1 (cmake_minimum_required):
[cmake]   Compatibility with CMake < 3.5 will be removed from a future version of
[cmake]   CMake.
[cmake] 
[cmake]   Update the VERSION argument <min> value or use a ...<max> suffix to tell
[cmake]   CMake that the project does not need compatibility with older versions.
[cmake] 
[cmake] 
[cmake] CMake Warning (dev) at<snip!>/tiny-aes-src/CMakeLists.txt:3 (project):
[cmake]   Policy CMP0048 is not set: project() command manages VERSION variables.
[cmake]   Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
[cmake]   command to set the policy and suppress this warning.
[cmake] 
[cmake]   The following variable(s) would be set to empty:
[cmake] 
[cmake]     PROJECT_VERSION
[cmake]     PROJECT_VERSION_MAJOR
[cmake]     PROJECT_VERSION_MINOR
[cmake]     PROJECT_VERSION_PATCH
[cmake] This warning is for project developers.  Use -Wno-dev to suppress it.
[cmake] 
```
I tested the build behaviour with cmake 3.28 and 3.29.
Since the main CMakeLists.txt does not rely on any policies changed between version 3.12 I assume that this change is safe to incorporate and will not break building anywhere else